### PR TITLE
chore(tsconfig): add noUnusedLocals

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release:major": "npm version major -m 'chore(package): v%s'",
     "release:minor": "npm version minor -m 'chore(package): v%s'",
     "test": "yarn test:lint && yarn test:unit",
-    "test:lint": "tslint 'src/*.ts src/**/*.ts'",
+    "test:lint": "tslint --type-check --project tsconfig.json",
     "test:unit": "mocha -r ts-node/register 'src/**/*.test.ts'"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "noImplicitAny": true,
     "sourceMap": true,
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictNullChecks": true
   },

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,9 @@
     "@motorcycle/tslint"
   ],
   "rules": {
-    "class-name": false
+    "class-name": false,
+    "no-unused-variable": [
+      false
+    ]
   }
 }


### PR DESCRIPTION
Force test:lint to type-check.

Set no-unused-variables to false to prevent tslint warnings,
caused by the added noUnusedLocals.

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed or the feature I built
- [x] I ran `yarn test` for the package I'm modifying
- [ ] I used `yarn commit` instead of `git commit`